### PR TITLE
Set objc class name for Session 

### DIFF
--- a/sources/SoundcloudSDK/soundcloud/SouncloudClient.swift
+++ b/sources/SoundcloudSDK/soundcloud/SouncloudClient.swift
@@ -98,6 +98,7 @@ extension PaginatedAPIResponse {
 // MARK: - Session
 
 #if os(iOS) || os(OSX)
+@objc(SoundcloudSession)
 public class Session: NSObject, NSCoding, NSCopying {
     //First session info
     public private(set) var authorizationCode: String

--- a/sources/SoundcloudSDK/soundcloud/SouncloudClient.swift
+++ b/sources/SoundcloudSDK/soundcloud/SouncloudClient.swift
@@ -355,16 +355,14 @@ public class SoundcloudClient: NSObject {
 
 
     /// The session property is only set when a user has logged in.
-    public fileprivate(set) static var session: Session? {
-        get {
-            if let data = keychain[data: sessionKey],
-                let session = NSKeyedUnarchiver.unarchiveObject(with: data) as? Session {
-                return session
-            }
-            return nil
+    public fileprivate(set) static var session: Session? = {
+        if let data = keychain[data: sessionKey],
+            let session = NSKeyedUnarchiver.unarchiveObject(with: data) as? Session {
+            return session
         }
-
-        set(newSession) {
+        return nil
+    }() {
+        willSet(newSession) {
             if let session = newSession {
                 let data = NSKeyedArchiver.archivedData(withRootObject: session)
                 keychain[data: sessionKey] = data

--- a/sources/SoundcloudSDK/soundcloud/SouncloudClient.swift
+++ b/sources/SoundcloudSDK/soundcloud/SouncloudClient.swift
@@ -355,15 +355,17 @@ public class SoundcloudClient: NSObject {
 
 
     /// The session property is only set when a user has logged in.
-    public fileprivate(set) static var session: Session? = {
-        if let data = keychain[data: sessionKey],
-            let session = NSKeyedUnarchiver.unarchiveObject(with: data) as? Session {
-            return session
+    public fileprivate(set) static var session: Session? {
+        get {
+            if let data = keychain[data: sessionKey],
+                let session = NSKeyedUnarchiver.unarchiveObject(with: data) as? Session {
+                return session
+            }
+            return nil
         }
-        return nil
-    }() {
-        didSet {
-            if let session = session {
+
+        set(newSession) {
+            if let session = newSession {
                 let data = NSKeyedArchiver.archivedData(withRootObject: session)
                 keychain[data: sessionKey] = data
             } else {
@@ -442,7 +444,7 @@ public class SoundcloudClient: NSObject {
     #endif
 
 
-    // MARK: Resolve 
+    // MARK: Resolve
 
     /// A resolve response can either be a/some User(s) or a/some Track(s) or a Playlist.
     public typealias ResolveResponse = (users: [User]?, tracks: [Track]?, playlist: Playlist?)


### PR DESCRIPTION
To have consistent keying with NSKeyed(Un)Archiver, an objc class name needs to be specified otherwise Swift will generate an objc class name. This may not be consistent across different versions of the library and will cause `NSInvalidUnarchiveOperationException` to be thrown