### PR TITLE
added shield to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ SoundcloudSDK
 ![Cocoapods Compatible](https://img.shields.io/cocoapods/v/Soundcloud.svg)
 ![Platform iOS | tvOS](https://img.shields.io/badge/platform-iOS%20%7C%20tvOS%20%7C%20OSX-lightgrey.svg)
 [![Contact](https://img.shields.io/badge/contact-%40kdelannoy-blue.svg)](https://twitter.com/kdelannoy)
+[![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/Soundcloud/functions?utm_source=SoundcloudGithub&utm_medium=button&utm_content=Vender_GitHub)
 
 SoundcloudSDK is a framework written in Swift over Soundcloud API.
 


### PR DESCRIPTION
Hey there. I added a link to the README for a tool where you can test out the Soundcloud API calls in your browser. It's pretty cool because you can export the code snippet into multiple languages as well. I thought it would be useful because I've seen it on other SDKs (Telegram, Shopify and LinkedIn). Full disclosure--I do work on the team that built this tool, but honestly, people seem to find it useful for this kind of stuff.